### PR TITLE
Adds extra delegate method for scrolling as the result of animation

### DIFF
--- a/DMLazyScrollViewExample/DMLazyScrollView/DMLazyScrollView.h
+++ b/DMLazyScrollViewExample/DMLazyScrollView/DMLazyScrollView.h
@@ -26,6 +26,7 @@ enum {
 @optional
 - (void)lazyScrollViewWillBeginDragging:(DMLazyScrollView *)pagingView;
 - (void)lazyScrollViewDidScroll:(DMLazyScrollView *)pagingView at:(CGPoint) visibleOffset;
+- (void)lazyScrollViewDidScroll:(DMLazyScrollView *)pagingView at:(CGPoint) visibleOffset withDirectUserManipulation:(BOOL)directManipulation;
 - (void)lazyScrollViewDidEndDragging:(DMLazyScrollView *)pagingView;
 - (void)lazyScrollViewWillBeginDecelerating:(DMLazyScrollView *)pagingView;
 - (void)lazyScrollViewDidEndDecelerating:(DMLazyScrollView *)pagingView atPageIndex:(NSInteger)pageIndex;

--- a/DMLazyScrollViewExample/DMLazyScrollView/DMLazyScrollView.h
+++ b/DMLazyScrollViewExample/DMLazyScrollView/DMLazyScrollView.h
@@ -25,7 +25,9 @@ enum {
 @protocol DMLazyScrollViewDelegate <NSObject>
 @optional
 - (void)lazyScrollViewWillBeginDragging:(DMLazyScrollView *)pagingView;
+//Called when it scrolls, except from as the result of self-driven animation.
 - (void)lazyScrollViewDidScroll:(DMLazyScrollView *)pagingView at:(CGPoint) visibleOffset;
+//Called whenever it scrolls: through user manipulation, setup, or self-driven animation.
 - (void)lazyScrollViewDidScroll:(DMLazyScrollView *)pagingView at:(CGPoint) visibleOffset withDirectUserManipulation:(BOOL)directManipulation;
 - (void)lazyScrollViewDidEndDragging:(DMLazyScrollView *)pagingView;
 - (void)lazyScrollViewWillBeginDecelerating:(DMLazyScrollView *)pagingView;

--- a/DMLazyScrollViewExample/DMLazyScrollView/DMLazyScrollView.h
+++ b/DMLazyScrollViewExample/DMLazyScrollView/DMLazyScrollView.h
@@ -28,7 +28,7 @@ enum {
 //Called when it scrolls, except from as the result of self-driven animation.
 - (void)lazyScrollViewDidScroll:(DMLazyScrollView *)pagingView at:(CGPoint) visibleOffset;
 //Called whenever it scrolls: through user manipulation, setup, or self-driven animation.
-- (void)lazyScrollViewDidScroll:(DMLazyScrollView *)pagingView at:(CGPoint) visibleOffset withDirectUserManipulation:(BOOL)directManipulation;
+- (void)lazyScrollViewDidScroll:(DMLazyScrollView *)pagingView at:(CGPoint) visibleOffset withSelfDrivenAnimation:(BOOL)selfDrivenAnimation;
 - (void)lazyScrollViewDidEndDragging:(DMLazyScrollView *)pagingView;
 - (void)lazyScrollViewWillBeginDecelerating:(DMLazyScrollView *)pagingView;
 - (void)lazyScrollViewDidEndDecelerating:(DMLazyScrollView *)pagingView atPageIndex:(NSInteger)pageIndex;

--- a/DMLazyScrollViewExample/DMLazyScrollView/DMLazyScrollView.m
+++ b/DMLazyScrollViewExample/DMLazyScrollView/DMLazyScrollView.m
@@ -201,7 +201,7 @@ enum {
 - (void) scrollViewDidScroll:(UIScrollView *)scrollView {
     if (isManualAnimating) {
         if (nil != controlDelegate && [controlDelegate respondsToSelector:@selector(lazyScrollViewDidScroll:at:withDirectUserManipulation:)]) {
-            [controlDelegate lazyScrollViewDidScroll:self at:[self visibleRect].origin withDirectUserManipulation:NO];
+            [controlDelegate lazyScrollViewDidScroll:self at:[self visibleRect].origin withSelfDrivenAnimation:YES];
         }
         return;
     }
@@ -248,7 +248,7 @@ enum {
     
     // alert delegate
     if (nil != controlDelegate && [controlDelegate respondsToSelector:@selector(lazyScrollViewDidScroll:at:withDirectUserManipulation:)]) {
-        [controlDelegate lazyScrollViewDidScroll:self at:[self visibleRect].origin withDirectUserManipulation:YES];
+        [controlDelegate lazyScrollViewDidScroll:self at:[self visibleRect].origin withSelfDrivenAnimation:NO];
     }
     else if (nil != controlDelegate && [controlDelegate respondsToSelector:@selector(lazyScrollViewDidScroll:at:)]) {
         [controlDelegate lazyScrollViewDidScroll:self at:[self visibleRect].origin];

--- a/DMLazyScrollViewExample/DMLazyScrollView/DMLazyScrollView.m
+++ b/DMLazyScrollViewExample/DMLazyScrollView/DMLazyScrollView.m
@@ -203,9 +203,6 @@ enum {
         if (nil != controlDelegate && [controlDelegate respondsToSelector:@selector(lazyScrollViewDidScroll:at:withDirectUserManipulation:)]) {
             [controlDelegate lazyScrollViewDidScroll:self at:[self visibleRect].origin withDirectUserManipulation:NO];
         }
-        else if (nil != controlDelegate && [controlDelegate respondsToSelector:@selector(lazyScrollViewDidScroll:at:)]) {
-            [controlDelegate lazyScrollViewDidScroll:self at:[self visibleRect].origin];
-        }
         return;
     }
     

--- a/DMLazyScrollViewExample/DMLazyScrollView/DMLazyScrollView.m
+++ b/DMLazyScrollViewExample/DMLazyScrollView/DMLazyScrollView.m
@@ -200,7 +200,7 @@ enum {
 
 - (void) scrollViewDidScroll:(UIScrollView *)scrollView {
     if (isManualAnimating) {
-        if (nil != controlDelegate && [controlDelegate respondsToSelector:@selector(lazyScrollViewDidScroll:at:withDirectUserManipulation:)]) {
+        if (nil != controlDelegate && [controlDelegate respondsToSelector:@selector(lazyScrollViewDidScroll:at:withSelfDrivenAnimation:)]) {
             [controlDelegate lazyScrollViewDidScroll:self at:[self visibleRect].origin withSelfDrivenAnimation:YES];
         }
         return;
@@ -247,7 +247,7 @@ enum {
     [self setCurrentViewController:newPageIndex];
     
     // alert delegate
-    if (nil != controlDelegate && [controlDelegate respondsToSelector:@selector(lazyScrollViewDidScroll:at:withDirectUserManipulation:)]) {
+    if (nil != controlDelegate && [controlDelegate respondsToSelector:@selector(lazyScrollViewDidScroll:at:withSelfDrivenAnimation:)]) {
         [controlDelegate lazyScrollViewDidScroll:self at:[self visibleRect].origin withSelfDrivenAnimation:NO];
     }
     else if (nil != controlDelegate && [controlDelegate respondsToSelector:@selector(lazyScrollViewDidScroll:at:)]) {

--- a/DMLazyScrollViewExample/DMLazyScrollView/DMLazyScrollView.m
+++ b/DMLazyScrollViewExample/DMLazyScrollView/DMLazyScrollView.m
@@ -199,7 +199,15 @@ enum {
 }
 
 - (void) scrollViewDidScroll:(UIScrollView *)scrollView {
-    if (isManualAnimating) return;
+    if (isManualAnimating) {
+        if (nil != controlDelegate && [controlDelegate respondsToSelector:@selector(lazyScrollViewDidScroll:at:withDirectUserManipulation:)]) {
+            [controlDelegate lazyScrollViewDidScroll:self at:[self visibleRect].origin withDirectUserManipulation:NO];
+        }
+        else if (nil != controlDelegate && [controlDelegate respondsToSelector:@selector(lazyScrollViewDidScroll:at:)]) {
+            [controlDelegate lazyScrollViewDidScroll:self at:[self visibleRect].origin];
+        }
+        return;
+    }
     
     CGFloat offset = (_direction==DMLazyScrollViewDirectionHorizontal) ? scrollView.contentOffset.x : scrollView.contentOffset.y;
     CGFloat size =(_direction==DMLazyScrollViewDirectionHorizontal) ? self.frame.size.width : self.frame.size.height;
@@ -242,8 +250,12 @@ enum {
     [self setCurrentViewController:newPageIndex];
     
     // alert delegate
-    if (nil != controlDelegate && [controlDelegate respondsToSelector:@selector(lazyScrollViewDidScroll:at:)])
+    if (nil != controlDelegate && [controlDelegate respondsToSelector:@selector(lazyScrollViewDidScroll:at:withDirectUserManipulation:)]) {
+        [controlDelegate lazyScrollViewDidScroll:self at:[self visibleRect].origin withDirectUserManipulation:YES];
+    }
+    else if (nil != controlDelegate && [controlDelegate respondsToSelector:@selector(lazyScrollViewDidScroll:at:)]) {
         [controlDelegate lazyScrollViewDidScroll:self at:[self visibleRect].origin];
+    }
 }
 
 - (void) setCurrentViewController:(NSInteger) index {


### PR DESCRIPTION
Adds an optional delegate method, which calls the delegate whenever it scrolls, as the result of self-driven animation or otherwise, and tells the delegate whether it was caused by self-driven animation or not.
